### PR TITLE
Add metadata requests to pint API (CSE-20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ all information at that level.
 
 For example:
 
+**Metadata APIs**
+```
+https://susepubliccloudinfo.suse.com/v1/providers.json
+```
+Will return list of all providers in JSON format 
+
+```
+https://susepubliccloudinfo.suse.com/v1/images/states.json
+```
+Will return list of all image states in JSON format
+
+```
+https://susepubliccloudinfo.suse.com/v1/amazon/servers/types.json
+```
+Will return list of all server types in Amazon in JSON format
+
+```
+https://susepubliccloudinfo.suse.com/v1/amazon/regions.json
+```
+Will return list of all known regions in Amazon in JSON format
+
+**Specific APIs**
 ```
 https://susepubliccloudinfo.suse.com/v1/microsoft/West%20US/servers/smt.json
 ```
@@ -113,3 +135,40 @@ Client Implementation
 
 `pint`, our Python-based client, is available in the Public Cloud Module, or in
 the Cloud:Tools project in OBS, as `python-susepubliccloudinfo`.
+
+Development
+-----------
+The following steps are only recommended if you want to build this project from sources, work on the codebase or test the latest development changes
+
+  1. **Install Git**
+
+         $ sudo zypper in git
+
+  2. **Install basic Ruby environment**
+
+         $ sudo zypper in ruby
+
+  3. **Install dependencies**
+
+     Install packages needed to compile Gems with native extensions:
+
+         $ sudo zypper in gcc make ruby-devel ruby2.5-rubygem-rack
+
+  4. **Clone public-cloud-info-service repository and install Gem dependencies**
+
+         $ git clone https://github.com/SUSE-Enceladus/public-cloud-info-service.git 
+         $ cd public-cloud-info-service 
+         $ bundle install
+
+  6. **In order to run REST APIs on the host**
+        
+         $ cd public-cloud-info-service
+         $ export FRAMEWORKS=spec/fixtures/framework*.xml
+         $ rackup
+         
+      To run REST APIs, point your browser to http://127.0.0.1:9292/
+
+  7. **In order to run tests**
+   
+         $ cd public-cloud-info-service
+         $ rspec

--- a/app.rb
+++ b/app.rb
@@ -175,6 +175,50 @@ class PublicCloudInfoSrv < Sinatra::Base
     end
   end
 
+  def form_xml_for_settings(tag, values)
+    Nokogiri::XML::Builder.new do |xml|
+      xml.root do
+        values.each { |value| xml.send(tag, name: value) }
+      end
+    end.doc.css(tag)
+  end
+
+  get '/v1/providers.?:ext?' do
+    validate_params_ext
+
+    responses = form_xml_for_settings('provider', settings.providers)
+
+    respond_with params[:ext], :providers, responses
+  end
+
+  get '/v1/:provider/servers/types.?:ext?' do
+    validate_params_ext
+    validate_params_provider
+
+    responses = form_xml_for_settings('type', settings.server_types)
+
+    respond_with params[:ext], :types, responses
+  end
+
+  get '/v1/images/states.?:ext?' do
+    validate_params_ext
+
+    responses = form_xml_for_settings('state', settings.image_states)
+
+    respond_with params[:ext], :states, responses
+  end
+
+  get '/v1/:provider/regions.?:ext?' do
+    validate_params_ext
+    validate_params_provider
+
+    responses = form_xml_for_settings(
+      'region', settings.regions[params[:provider]]
+    )
+
+    respond_with params[:ext], :regions, responses
+  end
+
   get '/v1/:provider/:region/servers/:server_type.?:ext?' do
     validate_params_ext
     validate_params_server_type

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -513,3 +513,96 @@ describe 'environmented images: /v1/microsoft' do
     end
   end
 end
+
+# we test the metadata APIs for amazon
+describe 'metadata APIs' do
+  describe 'providers list' do
+    before do
+      @path = '/v1/providers.xml'
+    end
+
+    it 'responds successfully' do
+      get 'v1/providers'
+      expect(last_response.status).to eq 200
+    end
+
+    it 'matches Json provider list' do
+      get 'v1/providers'
+      expect(last_response.body).to eq(
+        '{"providers":[{"name":"amazon"},{"name":"google"},' \
+        '{"name":"microsoft"},{"name":"oracle"}]}'
+      )
+    end
+
+    it 'matches Xml provider list' do
+      compare_with_fixture(@path)
+    end
+  end
+
+  describe 'server types list' do
+    before do
+      @path = '/v1/amazon/servers/types.xml'
+    end
+
+    it 'responds successfully' do
+      get 'v1/amazon/servers/types'
+      expect(last_response.status).to eq 200
+    end
+
+    it 'matches server types list' do
+      get 'v1/amazon/servers/types'
+      expect(last_response.body).to eq(
+        '{"types":[{"name":"smt"},{"name":"regionserver"}]}'
+      )
+    end
+
+    it 'matches server types XML list' do
+      compare_with_fixture(@path)
+    end
+  end
+
+  describe 'image states' do
+    before do
+      @path = '/v1/images/states.xml'
+    end
+
+    it 'responds successfully' do
+      get 'v1/images/states'
+      expect(last_response.status).to eq 200
+    end
+
+    it 'matches image state list' do
+      get 'v1/images/states'
+      expect(last_response.body).to eq(
+        '{"states":[{"name":"active"},{"name":"inactive"},' \
+        '{"name":"deprecated"},{"name":"deleted"}]}'
+      )
+    end
+
+    it 'matches image state XML list' do
+      compare_with_fixture(@path)
+    end
+  end
+
+  describe 'regions list in amazon' do
+    before do
+      @path = '/v1/amazon/regions.xml'
+    end
+
+    it 'responds successfully' do
+      get 'v1/amazon/regions'
+      expect(last_response.status).to eq 200
+    end
+
+    it 'matches partially region list' do
+      get 'v1/amazon/regions'
+      expect(last_response.body).to eq(
+        '{"regions":[{"name":"us-west-2"}]}'
+      )
+    end
+
+    it 'matches partially region XML list' do
+      compare_with_fixture(@path)
+    end
+  end
+end

--- a/spec/fixtures/v1/amazon/regions.xml
+++ b/spec/fixtures/v1/amazon/regions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<regions>
+  <region name="us-west-2"/>
+</regions>

--- a/spec/fixtures/v1/amazon/servers/types.xml
+++ b/spec/fixtures/v1/amazon/servers/types.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<types>
+  <type name="smt"/>
+  <type name="regionserver"/>
+</types>

--- a/spec/fixtures/v1/images/states.xml
+++ b/spec/fixtures/v1/images/states.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<states>
+  <state name="active"/>
+  <state name="inactive"/>
+  <state name="deprecated"/>
+  <state name="deleted"/>
+</states>

--- a/spec/fixtures/v1/providers.xml
+++ b/spec/fixtures/v1/providers.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<providers>
+  <provider name="amazon"/>
+  <provider name="google"/>
+  <provider name="microsoft"/>
+  <provider name="oracle"/>
+</providers>


### PR DESCRIPTION
Added APIs to allow users to query for available metadata

/v1/providers.?ext? - user can query Pint via REST api consistent with existing queries for a list of known providers/frameworks
/v1/:provider/regions.?ext? - user can query Pint via REST api consistent with existing queries for a list of known regions
/v1/:provider/images/states.?.ext? - user can query Pint via REST api consistent with existing queries for a list of states
/v1/:provider/servers/types.?ext? - user can query Pint via REST api consistent with existing queries for a list of server types

Added the tests for the new APIs
Modified README.md to add new APIs and also instructions to setup Development environment