### PR TITLE
Fix DocumentRoot path

### DIFF
--- a/publicCloudInfo-server.conf.template
+++ b/publicCloudInfo-server.conf.template
@@ -1,13 +1,13 @@
 <VirtualHost *:80>
-  ServerAdmin jgordon@suse.com
+  ServerAdmin admin@example.com
   ServerName susepubliccloudinfo.suse.com
-  DocumentRoot /srv/www/publicCloudInfoSrv/public
+  DocumentRoot /srv/www/publicCloudInfo-server/public
   Include /etc/apache2/conf.d/mod_passenger.conf
   # dev/test
   # SetEnv FRAMEWORKS /srv/www/publicCloudInfoSrv/spec/fixtures/framework-*.xml
   # production
   SetEnv FRAMEWORKS /etc/publicCloudInfo/*.xml
-  <Directory "/srv/www/publicCloudInfoSrv/public">
+  <Directory "/srv/www/publicCloudInfo-server/public">
     Options -MultiViews 
     <IfModule mod_access_compat.c>
     Order allow,deny


### PR DESCRIPTION
It should be /srv/www/publicCloudInfo-server/public instead of
/srv/www/publicCloudInfoSrv/public, according to
https://github.com/SUSE-Enceladus/public-cloud-info-service/blob/master/publicCloudInfo-server.spec#L55