### PR TITLE
Enable CORS requests from anywhere.

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -183,6 +183,10 @@ class PublicCloudInfoSrv < Sinatra::Base
     end.doc.css(tag)
   end
 
+  before do
+    headers 'Access-Control-Allow-Origin' => '*'
+  end
+
   get '/v1/providers.?:ext?' do
     validate_params_ext
 

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -31,9 +31,16 @@ end
 
 describe 'supported version' do
   describe 'v1' do
-    it 'responds successfully' do
+    before do
       get "v1/#{valid_providers.first}/#{valid_categories.first}"
+    end
+
+    it 'responds successfully' do
       expect(last_response.status).to eq 200
+    end
+
+    it 'enables CORS requests' do
+      expect(last_response.headers['Access-Control-Allow-Origin']).to eq('*')
     end
   end
 


### PR DESCRIPTION
As a developer of a web application that consumes _pint_ data, I require the API to implement Cross-Origin Resource Sharing (CORS).

As the _pint_ service is read-only, there's no risk in any web client consuming it (e.g. a client cannot be 'tricked' into pushing bad data, as nothing can be pushed), and credentials are not used, CORS can be enabled without limitation using a wildcard header: `Access-Control-Allow-Origin: *`, as defined in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin .