### PR TITLE
no region information for frameworks where images are global (CSE-66)

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -216,9 +216,16 @@ class PublicCloudInfoSrv < Sinatra::Base
     validate_params_ext
     validate_params_provider
 
-    responses = form_xml_for_settings(
-      'region', settings.regions[params[:provider]]
-    )
+    responses = if settings.regions[params[:provider]].empty?
+      form_xml_for_settings(
+        'region', Array['No region information available. '\
+        'Images have the same identifier in all regions']
+      )
+    else
+      form_xml_for_settings(
+        'region', settings.regions[params[:provider]]
+      )
+    end
 
     respond_with params[:ext], :regions, responses
   end

--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -626,3 +626,24 @@ describe 'google region images query' do
     end
   end
 end
+
+# we test the message returned when regions not supported
+describe 'Region API returns no info' do
+  describe 'regions list' do
+    before do
+      @path = '/v1/oracle/regions.xml'
+    end
+
+    it 'matches Json empty regions list' do
+      get 'v1/oracle/regions'
+      expect(last_response.body).to eq(
+        '{"regions":[{"name":"No region information available. ' \
+        'Images have the same identifier in all regions"}]}'
+      )
+    end
+
+    it 'matches Xml empty region list' do
+      compare_with_fixture(@path)
+    end
+  end
+end

--- a/spec/fixtures/v1/oracle/regions.xml
+++ b/spec/fixtures/v1/oracle/regions.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<regions>
+  <region name="No region information available. Images have the same identifier in all regions"/>
+</regions>


### PR DESCRIPTION
When we publish image information for a framework that has global images and no infrastructure we cannot provide user data for the regions API. In this case the response indicates to the user that regions are not supported.