### PR TITLE
apply azure region naming to the regions api (CSE-48)

### DIFF
--- a/spec/fixtures/framework-microsoft.xml
+++ b/spec/fixtures/framework-microsoft.xml
@@ -10,8 +10,9 @@
   </servers>
   <environments>
     <environment name="PublicAzure">
-      <region name="West US"/>
-      <region name="uswest"/>
+      <region name="uswest">
+        <alternate name="West US"/>
+      </region>
     </environment>
     <environment name="Blackforest">
     </environment>

--- a/spec/fixtures/frameworks.xml
+++ b/spec/fixtures/frameworks.xml
@@ -27,8 +27,9 @@
     </servers>
     <environments>
       <environment name="PublicAzure">
-        <region name="West US"/>
-        <region name="uswest"/>
+        <region name="uswest">
+          <alternate name="West US"/>
+        </region>
       </environment>
       <environment name="Blackforest">
       </environment>


### PR DESCRIPTION
Azure is often inconsistent in its naming scheme for regions. In order to fix this issue, Added an alternate name under every region in microsoft.xml and updated the server code to implement this change.