### PR TITLE
Pint service provides an endpoint with the current data version 

### DIFF
--- a/spec/features/app_spec.rb
+++ b/spec/features/app_spec.rb
@@ -626,3 +626,27 @@ describe 'google region images query' do
     end
   end
 end
+
+describe 'data version API' do
+  describe 'data version info' do
+    before do
+      @path = '/v1/data-version.xml'
+    end
+
+    it 'responds successfully' do
+      get 'v1/data-version'
+      expect(last_response.status).to eq 200
+    end
+
+    it 'matches Json data version info' do
+      get 'v1/data-version'
+      expect(last_response.body).to eq(
+        '{"versions":[{"name":"2021.01.15"}]}'
+      )
+    end
+
+    it 'matches Xml data version info' do
+      compare_with_fixture(@path)
+    end
+  end
+end

--- a/spec/fixtures/pint-data/.bumpversion.cfg
+++ b/spec/fixtures/pint-data/.bumpversion.cfg
@@ -1,0 +1,8 @@
+[bumpversion]
+current_version = 2021.01.15
+commit = True
+tag = True
+
+[bumpversion:file:data/publicCloudInfo-data.spec]
+search = Version:   {current_version}
+replace = Version:   {new_version}

--- a/spec/fixtures/pint-data/data/frameworks.xml
+++ b/spec/fixtures/pint-data/data/frameworks.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<frameworks>
+  <framework name="amazon">
+    <images>
+      <image deletedon="" deprecatedon="" id="ami-9253f9ea" name="suse-sles-11-sp4-byos-v20180105-pv-ssd-x86_64" publishedon="20180105" region="us-west-2" replacementid="" replacementname="" state="active"/>
+      <image deletedon="" deprecatedon="" id="ami-e45df79c" name="suse-sles-11-sp4-v20180105-pv-ssd-x86_64" publishedon="20180105" region="us-west-2" replacementid="" replacementname="" state="active"/>
+    </images>
+  </framework>
+  <framework name="google">
+    <servers>
+      <server type="smt" name="smt-gce.susecloud.net" ip="35.228.142.43" region="europe-north1"/>
+      <server type="smt" name="smt-gce.susecloud.net" ip="35.228.148.188" region="europe-north1"/>
+    </servers>
+    <images>
+      <image name="suse-manager-4-1-server-byos-v20200721" state="active" replacementname="" publishedon="20200721" deprecatedon="" deletedon=""/>
+      <image name="suse-manager-4-1-proxy-byos-v20200721" state="active" replacementname="" publishedon="20200721" deprecatedon="" deletedon=""/>
+    </images>
+  </framework>
+  <framework name="microsoft">
+    <servers>
+      <server type="smt-sles" name="smt-azure.susecloud.net" ip="23.100.46.123" region="West US"/>
+      <server type="smt-sles" name="smt-azure.susecloud.net" ip="23.101.192.253" region="West US"/>
+      <server type="smt-sap" name="smt-azure.susecloud.net" ip="40.112.248.207" region="West US"/>
+      <server type="smt-sap" name="smt-azure.susecloud.net" ip="13.93.211.154" region="West US"/>
+      <server type="regionserver-sles" name="" ip="23.100.36.229" region="West US"/>
+      <server type="regionserver-sap" name="" ip="23.100.36.230" region="West US"/>
+    </servers>
+    <environments>
+      <environment name="PublicAzure">
+        <region name="uswest">
+          <alternate name="West US"/>
+        </region>
+      </environment>
+      <environment name="Blackforest">
+      </environment>
+      <environment name="Mooncake">
+        <region name="China North"/>
+      </environment>
+      <environment name="Fairfax">
+      </environment>
+    </environments>
+    <images>
+      <image name="suse-sles-11-sp3-v20150127" id="" state="active" replacementid="" replacementname="" publishedon="2015-01-27" deprecatedon="" deletedon="" environment="PublicAzure"/>
+      <image name="suse-sles-11-sp3-20140701-x86-64" id="" state="deprecated" replacementid="" replacementname="suse-sles-11-sp3-v20150127" publishedon="2014-07-01" deprecatedon="2015-01-27" deletedon="" environment="PublicAzure"/>
+      <image name="suse-sles-11-sp3-20140101-x86-64" id="" state="deleted" replacementid="" replacementname="suse-sles-11-sp3-20140701-x86-64" publishedon="2014-01-01" deprecatedon="2014-07-01" deletedon="2015-01-01" environment="PublicAzure"/>
+      <image name="suse-sles-11-sp3-v20150127" id="" state="active" replacementid="" replacementname="" publishedon="2015-01-27" deprecatedon="" deletedon="" environment="Mooncake"/>
+      <image name="suse-sles-11-sp3-20140701-x86-64" id="" state="deprecated" replacementid="" replacementname="suse-sles-11-sp3-v20150127" publishedon="2014-07-01" deprecatedon="2015-01-27" deletedon="" environment="Mooncake"/>
+      <image name="b4590d9e3ed742e4a1d46e5424aa335e__suse-sles-12-sp3-byos-v20180815" state="inactive" environment="PublicAzure" replacementname="" publishedon="20180815" deprecatedon="" deletedon="" urn="SUSE:SLES-BYOS:12-SP3:2018.08.15"/>
+    </images>
+  </framework>
+  <framework name="oracle">
+    <servers/>
+    <images>
+      <!-- SLES 12 -->
+      <image name="sles-12-sp4-byos-v20190628" state="active" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+      <!-- SLES 12 4 SAP -->
+      <image name="sles-12-sp4-sap-byos-v20190628" state="active" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+      <!-- SLES 15 -->
+      <image name="sles-15-byos-v20190628" state="inactive" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+      <image name="sles-15-sp1-byos-v20190628" state="active" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+      <!-- SLES 15 4 SAP -->
+      <image name="sles-15-sap-byos-v20190628" state="inactive" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+      <image name="sles-15-sp1-sap-byos-v20190628" state="active" replacementname="" publishedon="20190712" deprecatedon="" deletedon=""/>
+    </images>
+  </framework>
+</frameworks>

--- a/spec/fixtures/v1/data-version.xml
+++ b/spec/fixtures/v1/data-version.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<versions>
+  <version name="2021.01.15"/>
+</versions>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ ENV['RACK_ENV'] = 'test'
 ENV['FRAMEWORKS'] = File.expand_path(
   File.join(
     File.dirname(__FILE__),
-    'fixtures/frameworks.xml'
+    'fixtures/pint-data/data/frameworks.xml'
   )
 )
 


### PR DESCRIPTION
Pint REST API to be able to query for version information so as to know when there has been an update to the backend data.
Uses the bumpversion version data from pint-data/-/blob/master/.bumpversion.cfg as the version output for this purpose
Added the unit teststo validate version endpoint