### PR TITLE
Match redirect behavior

### DIFF
--- a/next_generation/app.py
+++ b/next_generation/app.py
@@ -363,12 +363,16 @@ def list_provider_resource(provider, category):
 
 @app.route('/', methods=['GET'])
 def redirect_to_public_cloud():
-    return redirect('https://www.suse.com/solutions/public-cloud/')
+    #return redirect('https://www.suse.com/solutions/public-cloud/')
+    headers = {
+        'Location': 'https://www.suse.com/solutions/public-cloud/',
+    }
+    return Response('', status=301, headers=headers)
 
 
 @app.route('/<path:path>')
 def catch_all(path):
-    abort(400)
+    abort(Response('', status=400))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Existing pint API uses status 301 for redirect and no body.

However, pint-ng/flask redirect uses 302 as default status
code and the following in the body:

```
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to target URL:
<a href="https://www.suse.com/solutions/public-cloud/">
https://www.suse.com/solutions/public-cloud/</a>.
If not click the link.
```

This change is to match the behavior of pint-ng with
the current pint api

Also the updated the catch_all with response with
no body to match the current pint behavior.