### PR TITLE
Add orm_exporttopostgres to bin/

### DIFF
--- a/bin/orm_exporttopostgres
+++ b/bin/orm_exporttopostgres
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+
+# Script to import the XML based pint data into a PostgreSQL DB
+# THis is a one time operation, the database is expceted to hav a table called
+# "postgres" that has no entries
+
+import argparse
+from datetime import datetime
+import glob
+import os
+import subprocess
+import sys
+
+from lxml import etree
+
+from pint_server.database import init_db
+from pint_server.models import (
+            ImageState,
+            ServerType,
+            AlibabaImagesModel,
+            AmazonImagesModel,
+            AmazonServersModel,
+            GoogleImagesModel,
+            GoogleServersModel,
+            MicrosoftImagesModel,
+            MicrosoftRegionMapModel,
+            MicrosoftServersModel,
+            OracleImagesModel,
+            VersionsModel
+        )
+
+import logging
+
+
+def gen_data_files_list(pint_data_repo=None):
+    
+    if pint_data_repo is None:
+        pint_data_repo = os.path.realpath(
+                             os.path.join(
+                                 os.path.dirname(os.path.abspath(__file__)),
+                                 "..", "..", "pint-data"))
+
+    logger.debug("Pint Data repo: %s", repr(pint_data_repo))
+
+    data_files_pattern = os.path.join(pint_data_repo, 'data', '*.xml')
+    logger.debug("Data Files pattern: %s", repr(data_files_pattern))
+
+    data_files = glob.glob(data_files_pattern)
+    logger.debug("Data Files: %s", repr(data_files))
+
+    return data_files
+
+def get_commit_date(data_file):
+    data_dir = os.path.dirname(data_file)
+
+    output = subprocess.run(["bash", "-c",
+                             "cd %s; git log -n1 --pretty='format:%s' "
+                             "--date='format:%s' %s" %
+                             (os.path.dirname(data_file), '%cd', '%Y%m%d',
+                              os.path.basename(data_file))],
+                             stdout=subprocess.PIPE)
+
+    return output.stdout.decode('utf-8')
+
+def extract_provider_data_rows(parent_node, child_name):
+    rows = []
+
+    for child_node in parent_node.findall(child_name):
+        row = {}
+        for attr, value in child_node.items():
+            if not value:
+                continue
+            if attr == 'type':
+                if 'smt' in value:
+                    attr_value = ServerType.update
+                else:
+                    attr_value = ServerType.region
+            elif attr == 'state':
+                attr_value = getattr(ImageState, value)
+            elif attr in ['deletedon', 'deprecatedon', 'publishedon']:
+                attr_value = datetime.strptime(value, "%Y%m%d").date()
+            else:
+                attr_value = value
+            row[attr] = attr_value
+        rows.append(row)
+
+    return rows
+
+def extract_provider_region_map_rows(parent_node):
+    rows = []
+
+    for environment in parent_node.findall('environment'):
+        env_name = environment.get('name')
+        for region in environment.findall('region'):
+            region_name = region.get('name')
+            row = dict(environment=env_name,
+                       region=region_name, 
+                       canonicalname=region_name)
+            rows.append(row)
+            for alternate in region.findall('alternate'):
+                row = dict(environment=env_name,
+                           region=alternate.get('name'), 
+                           canonicalname=region_name)
+                rows.append(row)
+        #con.commit()
+    return rows
+
+def extract_data_from_file(data_file, data_store):
+
+    commit_date = get_commit_date(data_file)
+    reg_map = None
+
+    provider = os.path.basename(data_file).split('.')[0]
+    # This version is just a "suggested" version that is
+    # derived from the date stamp; the actual version that
+    # will be set will depend on whether this suggested
+    # value is greater than the existing version, in which
+    # case it will be used. Otherwise the existing version
+    # will be incremented to indicate an incremental update
+    # of the table for the same date.
+    data_store[provider] = dict(version=f"{commit_date}.0",
+                                tables={})
+
+    logger.info("Extracting XML data for %s provider...", repr(provider))
+
+    with open(data_file) as dfp:
+        df_lines = dfp.readlines()
+        provider_tables = {}
+
+        # Strip any <xml> declaration from the start of file content to
+        # appease the XML parser if an encoding has been specified.
+        content = ''.join(df_lines[1:])
+        root = etree.fromstring(content)
+
+        for table_type in ['image', 'server']:
+            table_name = table_type + "s"
+            rows = extract_provider_data_rows(
+                        root.findall(table_name)[0], table_type)
+            provider_tables[table_name] = rows
+
+        if provider == 'microsoft':
+            rows = extract_provider_region_map_rows(
+                        root.findall('environments')[0])
+            provider_tables['regionmap'] = rows
+
+        data_store[provider]['tables'] = provider_tables
+
+def orm_update_table(db, provider, table_name, table_rows, version):
+    if table_name == "regionmap":
+        table_name_caps = "RegionMap"
+        need_version = False
+    else:
+        table_name_caps = table_name.capitalize()
+        need_version = True
+
+    model = eval(f"{provider.capitalize()}{table_name_caps}Model")
+    logger.debug("Using model %s for provider %s table %s",
+                 repr(model.__name__), repr(provider),
+                 repr(table_name))
+
+    logger.debug("Attempting to add %d new entries for model %s",
+                 len(table_rows), repr(model.__name__))
+    rows_added = 0
+    rows_updated = 0
+    for row_data in table_rows:
+        primary_data = {k:v for k, v in row_data.items()
+                            if getattr(model.__table__.columns,
+                                       k).primary_key}
+        # if we find no match for the primary keys they add a new row
+        found_row = db.query(model).filter_by(**primary_data).one_or_none()
+        if not found_row:
+            row = model(**row_data)
+            logger.debug("Adding new row %s", repr(row))
+            db.add(row)
+            rows_added += 1
+            continue
+
+        # Now check if the found row is an exact match?
+        if all([v == getattr(found_row, k)
+                for k, v in row_data.items()]):
+            logger.debug("Skipping existing row: %s", repr(found_row))
+            continue
+
+        logger.debug("Updating existing row: %s", repr(found_row))
+        for k, v in row_data.items():
+            setattr(found_row, k, v)
+        rows_updated += 1
+
+
+    if not rows_added and not rows_updated:
+        logger.info("No new entries found for model %s",
+                    repr(model.__name__))
+    else:
+        if rows_added:
+            logger.info("Added %d entries for model %s",
+                        rows_added, repr(model.__name__))
+
+        if rows_updated:
+            logger.info("Updated %d entries for model %s",
+                        rows_updated, repr(model.__name__))
+
+        if need_version:
+            # Lookup the existing version for the relevant table
+            version_entry = db.query(VersionsModel).\
+                               filter(VersionsModel.tablename==\
+                                      model.__tablename__).\
+                               one_or_none()
+
+            # If we found an exiting entry then we need to update
+            # the version value to reflect the incremental update.
+            if version_entry:
+                logger.info("Updating %s table entry for table %s with "
+                            "version %s", repr(VersionsModel.__tablename__),
+                            repr(model.__tablename__), repr(version))
+                # If the suggested version is >= the existing version
+                # we can just use it, as this means that the associated
+                # commit date stamp is newer than the previous one.
+                if float(version_entry.version) < float(version):
+                    version_entry.version = version
+                else:
+                    # If the existing version is newer than the suggested
+                    # one, which could happen if there has already been
+                    # an incremental update incorporated with the same
+                    # commit date stamp, or if an older merge request was
+                    # merged after a newer one, meaning that the most recent
+                    # commit was from a previous date, then we just add 0.01
+                    # to the existing version timestamp. This should allow us
+                    # to support up to 100 incremental merges per day while
+                    # maintaining the logical relationship between the commit
+                    # date stamp and the version, and will still work for a
+                    # higher incremental update rate, though the version value
+                    # would roll over to the next logical "date" in such cases.
+                    version_entry.version = float(version_entry.version) + 0.01
+            else:
+                # Otherwise we just add an initial version entry for
+                # this table based on the supplied version, which is
+                # derived from the commit date stamp.
+                logger.info("Adding %s table entry for table %s with "
+                            "version %s", repr(VersionsModel.__tablename__),
+                            repr(model.__tablename__), repr(version))
+                db.add(VersionsModel(tablename=model.__tablename__,
+                                     version=version))
+
+def orm_update_tables(db, provider, tables, version):
+    for table_name, table_rows in tables.items():
+        if not table_rows:
+            logger.debug("Skipping table %s for provider %s; no entries "
+                         "found", repr(table_name), repr(provider))
+            continue
+        orm_update_table(db, provider, table_name, table_rows, version)
+
+def orm_load_database(args):
+    os.environ['POSTGRES_HOST'] = args.host
+    os.environ['POSTGRES_PORT'] = str(args.port)
+    os.environ['POSTGRES_DATABASE'] = args.db
+    os.environ['POSTGRES_USER'] = args.user
+    os.environ['POSTGRES_PASSWORD'] = args.password
+
+    db = init_db()
+
+    data_files = gen_data_files_list()
+
+    # extract all the data from the data files
+    data_store = {}
+    for data_file in data_files:
+        extract_data_from_file(data_file, data_store)
+
+    # populate tables with data that was extracted
+    for provider, provider_info in data_store.items():
+        tables = provider_info['tables']
+        version = provider_info['version']
+        logger.debug("%s: %s", provider.capitalize(), repr(tables.keys()))
+
+        required_table_names = ['servers', 'images']
+        if provider == "microsoft":
+            required_table_names.append("regionmap")
+
+        for table_name in required_table_names:
+            if table_name not in tables:
+                logger.fatal("No %s table data for provider %s",
+                             repr(table_name), repr(provider))
+
+        orm_update_tables(db, provider, tables, version)
+
+    if db.new or db.dirty:
+        logger.debug("Added to the Database: %s", db.new)
+        logger.debug("Modified in the Database: %s", db.dirty)
+        db.commit()
+
+
+argparse = argparse.ArgumentParser(
+    description='Create PostgresSQL from pint XML data'
+)
+
+argparse.add_argument(
+    '--host',
+    dest='host',
+    required=True,
+    help='The host to which to connect to for the SQL connection'
+)
+
+argparse.add_argument(
+    '--password',
+    dest='password',
+    required=True,
+    help='The SQL DB password'
+)
+
+argparse.add_argument(
+    '--user',
+    dest='user',
+    required=True,
+    help='The SQL DB user'
+)
+
+argparse.add_argument(
+    '--port',
+    dest='port',
+    type=int,
+    default=5432,
+    help='The SQL DB port'
+)
+
+argparse.add_argument(
+    '--db', '--database',
+    dest='db',
+    default='postgres',
+    help='The SQL DB name'
+)
+
+argparse.add_argument(
+    '--debug', '-d',
+    dest='debug',
+    action='store_true',
+    default=False,
+    help='Enable verbose & debug output'
+)
+
+argparse.add_argument(
+    '--verbose', '-v',
+    dest='verbose',
+    action='store_true',
+    default=False,
+    help='Enable verbose output'
+)
+
+
+args = argparse.parse_args()
+
+log_level = 'WARNING'
+if args.verbose:
+    log_level = 'INFO'
+
+if args.debug:
+    log_level = 'DEBUG'
+
+logging.basicConfig(level=log_level)
+
+logger = logging.getLogger(os.path.basename(__file__))
+
+orm_load_database(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-SQLAlchemy==2.4.4
 itsdangerous==1.1.0
 Jinja2==2.11.3
 jmespath==0.10.0
+lxml==4.6.3
 MarkupSafe==1.1.1
 psycopg2==2.8.6
 python-dateutil==2.8.1


### PR DESCRIPTION
Port the orm_exporttopostgres script to work with the new pint_server
implementation.

To use it you should clone the pint-data repo, that contains the XML
data to be import, beside the public-cloud-info-service; the script
will automatically look for the pint-data repo relative to it's own
location in the public-cloud-info-service/bin directory.

Run it by specifying the necessary command line arguments, e.g.

    % bin/orm_exporttopostgres --host ${POSTGRES_HOST} \
        --password ${POSTGRES_PASSWORD}
        --user ${POSTGRES_USER}

The script will create the database tables if not already created,
and will then import the XML content from the pint-data repo, either
as a full import if no data exists, or incrementally importing new
changes made since the last import.

For incremental updates, when updating the versions table, if the
existing version entry value is less than the detected commit date
stamp for the updates, then we will use the new commit date stamp,
otherwise we will add 0.01 to the existing date stamp value. This
should allow us to support up to 100 incremental merges for the
same date without issues, and will still work if we ever have more
than that number of incremental updates, though the relationship
between the version value and the associated commit data may be
lost.

To test the incremental update support I used the following shell
command when cd'd into a pint data repo clone, with this repo
cloned beside it:

    % for i in $(seq 90 -1 0); do git co origin/master~${i} && \
      ../public-cloud-info-service/bin/orm_exporttopostgres \
          --host ${POSTGRES_HOST} \
          --password ${POSTGRES_PASSWORD} \
          --user ${POSTGRES_USER}; done

Include lmxl (v4.6.3) in the requirements.txt to support running
the orm_exporttopostgres script.