### PR TITLE
fix discrepancies between Pint and Pint NG

### DIFF
--- a/bin/run_standalone.sh
+++ b/bin/run_standalone.sh
@@ -40,4 +40,4 @@ export POSTGRES_HOST=127.0.0.1
 
 export FLASK_ENV=development
 
-env FLASK_APP=$SRCDIR/pint_server/app.py flask run
+env FLASK_APP=$SRCDIR/pint_server/app.py flask run -h 0.0.0.0


### PR DESCRIPTION
1. if 'changeinfo' is empty, don't return it
2. if 'urn' is empty, don't return it
3. for Alibaba and Oracle where we don't have any servers, we'll return
   an empty list when query by server type in order to be backward
   compatible
4. add mapping to map the original server types (i.e. smt, regionserver-sles,
   regionserver-sap, etc) to the new server types (i.e. update and region)
   in order to maintain backward compatibility