### PR TITLE
use psycopg2-binary instead of psycopy2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jmespath==0.10.0
 lxml==4.6.3
 MarkupSafe==1.1.1
 pbr==5.6.0
-psycopg2==2.8.6
+psycopg2-binary
 python-dateutil==2.8.1
 s3transfer==0.3.6
 serverless-wsgi==1.7.6


### PR DESCRIPTION
We don't want to recomplike the PostgreSQL DB driver on install as it
requires both gcc and postgresql12-server-devel packages.