### PR TITLE
Add an API to return the package version

### DIFF
--- a/SUSE.rst
+++ b/SUSE.rst
@@ -61,7 +61,7 @@ Testing Pint Server Lamba Function Container Locally
 How To Make A Release
 =====================
 
-1. update setup.cfg with the new version
+1. update pint_server/__init__.py '__VERSION__' attribute with the new version
 
 2. create a git annotated tag for the release version. For example:
 

--- a/pint_server/__init__.py
+++ b/pint_server/__init__.py
@@ -15,6 +15,9 @@
 # To contact SUSE about this file by physical or electronic mail,
 # you may find current contact information at www.suse.com
 
+# NOTE(gyee): must update the version here on a new release
+__VERSION__ = '2.0.3'
+
 from pint_server.database import init_db
 from pint_server.models import (AlibabaImagesModel, AmazonImagesModel,
                     AmazonServersModel, GoogleImagesModel,

--- a/pint_server/app.py
+++ b/pint_server/app.py
@@ -28,6 +28,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from xml.dom import minidom
 import xml.etree.ElementTree as ET
 
+import pint_server
 from pint_server.database import init_db
 from pint_server.models import (ImageState, AmazonImagesModel,
                                 OracleImagesModel, AlibabaImagesModel,
@@ -548,6 +549,12 @@ def get_provider_category_data_version(provider):
     assert_valid_category(category)
     version = get_data_version_for_provider_category(provider, category)
     return make_response(version, None, None)
+
+
+@app.route('/package-version', methods=['GET'])
+def get_package_version():
+    return make_response(
+        {'package version': pint_server.__VERSION__}, None, None)
 
 
 @app.route('/', methods=['GET'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pint-server
-version = 2.0.3
+version = attr: pint_server.__VERSION__
 author = Guang Yee
 author_email = gyee@suse.com
 description = Pint Server


### PR DESCRIPTION
Add an API to return the package version of the code to improve
deployability. The new API is

GET /package-version

and it will return something like this

{
  "package version": "2.0.3"
}