### PR TITLE
Add unique constraint to MicrosoftImagesModel

### DIFF
--- a/pint_server/__init__.py
+++ b/pint_server/__init__.py
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 # NOTE(gyee): must update the version here on a new release
-__VERSION__ = '2.0.4'
+__VERSION__ = '2.0.5'
 
 from pint_server.database import (
     init_db, create_postgres_url_from_config

--- a/pint_server/data_update.py
+++ b/pint_server/data_update.py
@@ -195,10 +195,10 @@ def extract_data_from_file(data_file, data_store):
 
 # Per-table overrides to used for existing entry checks
 IDENTITY_OVERRIDES = {
-    # The microsoftimages table now uses a sequence entry as the
-    # primary key, so use the values of these columns when checking
-    # for existing entries.
-    MicrosoftImagesModel.__name__: ['name', 'environment']
+    # For the microsoftimages use the column names associated with the
+    # first unique constraint as the identity override column list.
+    MicrosoftImagesModel.__name__: [
+        c.name for c in MicrosoftImagesModel.unique_constraints()[0]]
 }
 
 def orm_update_table(db, provider, table_name, table_rows, version):

--- a/pint_server/models.py
+++ b/pint_server/models.py
@@ -17,7 +17,7 @@
 
 import enum
 
-from sqlalchemy import Column, Date, Enum, Integer, Numeric, String
+from sqlalchemy import Column, Date, Enum, Integer, Numeric, String, UniqueConstraint
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import validates
@@ -51,6 +51,12 @@ class PintBase(object):
     def tablename(self):
         """Return table name."""
         return self.__tablename__
+
+    @classmethod
+    def unique_constraints(cls):
+        """Return the table's unique constraint's column names, or empty list."""
+        return [u for u in cls.__table__.constraints
+                if isinstance(u, UniqueConstraint)]
 
     def __repr__(self):
         return "<%s(%s)>" % (self.__class__.__name__,
@@ -117,6 +123,7 @@ class GoogleImagesModel(Base, ProviderImageBase):
 
 class MicrosoftImagesModel(Base, ProviderImageBase):
     __tablename__ = 'microsoftimages'
+    __table_args__ = (UniqueConstraint('name', 'environment'),)
 
     id = Column(Integer, primary_key=True)
     name = Column(String(255), nullable=False)

--- a/pint_server/pint_db_migrate/versions/8c5fc3cd9b18_microsoftimages_unique_constraint.py
+++ b/pint_server/pint_db_migrate/versions/8c5fc3cd9b18_microsoftimages_unique_constraint.py
@@ -1,0 +1,27 @@
+"""microsoftimages unique constraint
+
+Revision ID: 8c5fc3cd9b18
+Revises: e2bdb3a5b1b4
+Create Date: 2021-10-29 09:10:26.515096
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '8c5fc3cd9b18'
+down_revision = 'e2bdb3a5b1b4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add a new unique constraint to the microsoft images table based upon
+    # name and environment columns.
+    op.create_unique_constraint(None, 'microsoftimages', ['name', 'environment'])
+
+
+def downgrade():
+    # remove the added unique constraint.
+    op.drop_constraint(None, 'microsoftimages', type_='unique')

--- a/pint_server/pint_db_migrate/versions/8c5fc3cd9b18_microsoftimages_unique_constraint.py
+++ b/pint_server/pint_db_migrate/versions/8c5fc3cd9b18_microsoftimages_unique_constraint.py
@@ -5,6 +5,9 @@ Revises: e2bdb3a5b1b4
 Create Date: 2021-10-29 09:10:26.515096
 
 """
+import os
+import logging
+
 from alembic import op
 import sqlalchemy as sa
 
@@ -15,13 +18,77 @@ down_revision = 'e2bdb3a5b1b4'
 branch_labels = None
 depends_on = None
 
+logger = logging.getLogger(os.path.basename(__file__))
 
+#
+# Unique constraint definition settings
+#
+uc_table = 'microsoftimages'
+uc_fields = ['name', 'environment']
+
+#
+# Helper Methods
+#
+def report_duplicates(table, fields, _log=logger.warning):
+    """Generate an SQL query string of the format
+
+        SELECT table.field[0], table.field[1], ..., table.fields[n]
+        FROM table
+        GROUP BY table.field[0], table.field[1], ..., table.fields[n]
+        HAVING count(table.fields[0]) > 1
+
+    and use that to determine if any duplicates exist, reporting any
+    found via the specified logger."""
+
+    # Generate a list of '{table}.{field}' entries for unique fields,
+    # and comma joined string from that list
+    unique_fields = [f'{table}.{f}' for f in fields]
+    joined_unique_fields = ', '.join(unique_fields)
+
+    # Generate a list of strings that will be joined with
+    query_elements = []
+
+    # Add the SELECT statement for specified table_fields
+    query_elements.append(f'SELECT {joined_unique_fields}')
+
+    # Add the FROM statement specifying the table
+    query_elements.append(f'FROM {table}')
+
+    # Add the GROUP BY statement for specified the table fields
+    query_elements.append(f'GROUP BY {joined_unique_fields}')
+
+    # Add the HAVING count() check for the first unique field
+    query_elements.append(f'HAVING count({unique_fields[0]}) > 1')
+
+    # Generate an SQL text object for the proposed query string
+    duplicates_query = sa.text(' '.join(query_elements))
+
+    logger.debug('Duplicates Query: %s', duplicates_query)
+
+    # Check for duplicates
+    conn = op.get_bind()
+    duplicates = conn.execute(duplicates_query).fetchall()
+
+    if duplicates:
+        # Report the duplicates that were found
+        _log('Duplicates detected in microsoftimages:')
+        for row in duplicates:
+            _log('    %s', repr(dict(name=row[0], environment=row[1])))
+
+
+#
+# Mainline migration entry points
+#
 def upgrade():
-    # Add a new unique constraint to the microsoft images table based upon
-    # name and environment columns.
-    op.create_unique_constraint(None, 'microsoftimages', ['name', 'environment'])
+    # Check for and report any duplicates found for the fields in the
+    # proposed unique constraint
+    report_duplicates(uc_table, uc_fields)
+
+    # Add a new unique constraint to the 'microsoftimages' table based
+    # upon the name and environment columns.
+    op.create_unique_constraint(None, uc_table, uc_fields)
 
 
 def downgrade():
     # remove the added unique constraint.
-    op.drop_constraint(None, 'microsoftimages', type_='unique')
+    op.drop_constraint(None, uc_table, type_='unique')


### PR DESCRIPTION
Add a UniqueConstraint based upon the name and environment columns to
the MicrosoftImagesModel (microsoftimages) table definition.

Add a schema migration to upgrade the database to add the new unique
constraint to the microsoftimages.

Add a new class method to the PintBase class that returns the list of
defined unique constraints associated with a given table, or an empty
list if none are found.

Update the data_update.py IDENTITY_OVERRIDES mechanism to leverage the
new unique_constraints class method from PintBase when specifying an
override entry for the 'microsoftimages' table.

Report any duplicates found for the proposed unique constraint.
    
Any that are found will be reported as WARNING messages prior to the
attempt to add the new unique constraint.

Bump the version to 2.0.5

Closes: #97