### PR TITLE
Handle publishedon not yet set in data validator

### DIFF
--- a/pint_server/data_update.py
+++ b/pint_server/data_update.py
@@ -424,6 +424,7 @@ def update(ctx, pint_data, db_logfile):
     except Exception as e:
         LOG.debug(e, exc_info=True)
         print('Failed to upgrade Pint database: %s' % (e))
+        exit(1)
 
 
 pint_db.add_command(update)

--- a/pint_server/models.py
+++ b/pint_server/models.py
@@ -80,17 +80,26 @@ class ProviderImageBase(PintBase):
         deprecatedon = value if key == 'deprecatedon' else self.deprecatedon
         deletedon = value if key == 'deletedon' else self.deletedon
 
-        if deprecatedon and deprecatedon < publishedon:
-            raise ValueError('Image %s invalid dates specified - '
-                             'publishedon(%s) should not be after '
-                             'deprecatedon(%s)' % (self.name,
-                             str(publishedon), str(deprecatedon)))
+        # If called for deprecatedon or deletedon before publishedon
+        # has been set we have nothing to compare against, so just
+        # fall through and accept the provided value for now.
+        # Since the validator will be triggered for all 3 fields and
+        # performs the same checks each time, even if publishedon is
+        # the last field we are called for, the validator will still
+        # fail if either deprecatedon or deletedon is not valid with
+        # respect to that publishedon value.
+        if publishedon:
+            if deprecatedon and deprecatedon < publishedon:
+                raise ValueError('Image %s invalid dates specified - '
+                                 'publishedon(%s) should not be after '
+                                 'deprecatedon(%s)' % (self.name,
+                                 str(publishedon), str(deprecatedon)))
 
-        if deletedon and deletedon < publishedon:
-            raise ValueError('Image %s invalid dates specified - '
-                             'publishedon(%s) should not be after '
-                             'deletedon(%s)' % (self.name,
-                             str(publishedon), str(deletedon)))
+            if deletedon and deletedon < publishedon:
+                raise ValueError('Image %s invalid dates specified - '
+                                 'publishedon(%s) should not be after '
+                                 'deletedon(%s)' % (self.name,
+                                 str(publishedon), str(deletedon)))
 
         if deprecatedon and deletedon and deletedon < deprecatedon:
             raise ValueError('Image %s invalid dates specified - '

--- a/pint_server/schema_upgrade.py
+++ b/pint_server/schema_upgrade.py
@@ -109,6 +109,7 @@ def upgrade(ctx):
     except Exception as e:
         LOG.debug(e, exc_info=True)
         print('Failed to upgrade Pint database: %s' % (e))
+        exit(1)
 
 
 pint_db.add_command(db_version)


### PR DESCRIPTION
When validating the publishedon, deprecatedon, and deletedon fields
we need to wait until published on has been set before trying to do
any validations against it.

Since the same validation is performed when triggered for any of the
three fields, it needs to support being called for deprecatedon or
deletedon before publishedon without failing, while performing all
of the validation when called for publishedon.

Also ensure that the schema_upgrade.py and data_update.py scripts
exit with a failed exit status if a failure occurs.

Closes: #104 (again), #107