### PR TITLE
IP Addresses must be unique per region

### DIFF
--- a/bin/adhoc_db
+++ b/bin/adhoc_db
@@ -101,24 +101,21 @@ def duplicate_servers():
         _commit_db_changes(db, f'duplicate_servers ({table_name} add v4 '
                            'and v6 only entries)')
 
-        # Microsoft can have the same update server in multiple regions so add
-        # an update server entry in another region with both addresses
-        if table_name == 'microsoftservers':
-            LOG.debug('%s: Add other region entry', table_name)
-            row = model(**server_entry_args['v4_v6_eu'])
-            db.add(row)
+        LOG.debug('%s: Add other region entry', table_name)
+        row = model(**server_entry_args['v4_v6_eu'])
+        db.add(row)
 
-            try:
-                _commit_db_changes(db, f'duplicate_servers ({table_name} '
-                                   'add v4 and v6 other region entry)')
-                cleanup_entries.append(row)
+        try:
+            _commit_db_changes(db, f'duplicate_servers ({table_name} '
+                               'add v4 and v6 other region entry)')
+            cleanup_entries.append(row)
 
-            except Exception as e:
-                LOG.debug(e, exc_info=True)
-                LOG.error("%s: We should be able to add a duplicate "
-                        "server entry in a different region!", table_name)
-                test_results[table_name] = False
-                db.rollback()
+        except Exception as e:
+            LOG.debug(e, exc_info=True)
+            LOG.error("%s: We should be able to add a duplicate "
+                      "server entry in a different region!", table_name)
+            test_results[table_name] = False
+            db.rollback()
 
         LOG.debug('%s: Add invalid entry', table_name)
         row = model(**server_entry_args['v4_v6_us'])

--- a/pint_server/models.py
+++ b/pint_server/models.py
@@ -179,8 +179,8 @@ class AmazonServersModel(Base, ProviderServerBase):
     ipv6 = Column(postgresql.INET)
 
     __table_args__ = (
-        Index('uix_amazonservers_ip_not_null', 'ip', unique=True, postgresql_where=ip.isnot(None)),
-        Index('uix_amazonservers_ipv6_not_null', 'ipv6', unique=True, postgresql_where=ipv6.isnot(None)),
+        Index('uix_amazonservers_region_ip_not_null', 'region', 'ip', unique=True, postgresql_where=ip.isnot(None)),
+        Index('uix_amazonservers_region_ipv6_not_null', 'region', 'ipv6', unique=True, postgresql_where=ipv6.isnot(None)),
     )
 
 
@@ -195,8 +195,8 @@ class GoogleServersModel(Base, ProviderServerBase):
     ipv6 = Column(postgresql.INET)
 
     __table_args__ = (
-        Index('uix_googleservers_ip_not_null', 'ip', unique=True, postgresql_where=ip.isnot(None)),
-        Index('uix_googleservers_ipv6_not_null', 'ipv6', unique=True, postgresql_where=ipv6.isnot(None)),
+        Index('uix_googleservers_region_ip_not_null', 'region', 'ip', unique=True, postgresql_where=ip.isnot(None)),
+        Index('uix_googleservers_region_ipv6_not_null', 'region', 'ipv6', unique=True, postgresql_where=ipv6.isnot(None)),
     )
 
 

--- a/pint_server/pint_db_migrate/versions/e937749e3f8b_servers_partial_unique_keys.py
+++ b/pint_server/pint_db_migrate/versions/e937749e3f8b_servers_partial_unique_keys.py
@@ -23,13 +23,13 @@ logger = logging.getLogger(os.path.basename(__file__))
 #
 # Helper Methods
 #
-def report_duplicates(table, fields, _log=logger.warning):
+def report_duplicates(table, fields, count_field=0, _log=logger.warning):
     """Generate an SQL query string of the format
 
-        SELECT table.field[0], table.field[1], ..., table.fields[n]
+        SELECT table.fields[0], table.fields[1], ..., table.fields[n]
         FROM table
-        GROUP BY table.field[0], table.field[1], ..., table.fields[n]
-        HAVING count(table.fields[0]) > 1
+        GROUP BY table.fields[0], table.fields[1], ..., table.fields[n]
+        HAVING count(table.fields[count_field]) > 1
 
     and use that to determine if any duplicates exist, reporting any
     found via the specified logger."""
@@ -52,7 +52,7 @@ def report_duplicates(table, fields, _log=logger.warning):
     query_elements.append(f'GROUP BY {joined_unique_fields}')
 
     # Add the HAVING count() check for the first unique field
-    query_elements.append(f'HAVING count({unique_fields[0]}) > 1')
+    query_elements.append(f'HAVING count({unique_fields[count_field]}) > 1')
 
     # Generate an SQL text object for the proposed query string
     duplicates_query = sa.text(' '.join(query_elements))
@@ -74,26 +74,31 @@ def report_duplicates(table, fields, _log=logger.warning):
 # Define appropriate per table unique entry checks for ip and ipv6 addresses
 #
 unique_server_addresses_checks = [
-    ["amazonservers", ['ip']],
-    ["amazonservers", ['ipv6']],
-    ["googleservers", ['ip']],
-    ["googleservers", ['ipv6']],
-    ["microsoftservers", ['ip', 'region']],
-    ["microsoftservers", ['ipv6', 'region']],
+    ["amazonservers", ['region', 'ip']],
+    ["amazonservers", ['region', 'ipv6']],
+    ["googleservers", ['region', 'ip']],
+    ["googleservers", ['region', 'ipv6']],
+    ["microsoftservers", ['region', 'ip']],
+    ["microsoftservers", ['region', 'ipv6']],
 ]
 
 def upgrade():
 
     # Check for and warn about any duplicates that may exist in the servers tables
     for table, fields in unique_server_addresses_checks:
-        report_duplicates(table, fields)
+        report_duplicates(table, fields, count_field=1)
 
     # Add the unique indices; will fail if duplicates exist
     for table, fields in unique_server_addresses_checks:
-        op.create_index(f'uix_{table}_{fields[0]}_not_null', table, fields, unique=True, postgresql_where=sa.text(f'{fields[0]} IS NOT NULL'))
+        joined_fields = '_'.join(fields)
+        op.create_index(f'uix_{table}_{joined_fields}_not_null',
+                        table, fields, unique=True,
+                        postgresql_where=sa.text(f'{fields[1]} IS NOT NULL'))
 
 
 def downgrade():
     # Drop the unique indices
     for table, fields in reversed(unique_server_addresses_checks):
-        op.drop_index(f'uix_{table}_{fields[0]}_not_null', table_name=table, postgresql_where=sa.text(f'{fields[0]} IS NOT NULL'))
+        joined_fields = '_'.join(fields)
+        op.drop_index(f'uix_{table}_{joined_fields}_not_null',
+                      table_name=table)


### PR DESCRIPTION
Previously we defined new partial unique indices to ensure that IP
addresses were uniquely specified in the Amazon, Google and Microsoft
servers tables, though we allowed for them being unique per region in
the case of Microsoft.

However, we sometimes temporarily specify the update servers from an
existing region as the update servers for a newly created region until
the update infrastructure for the new region is in place.

To address this operational requirement we need to include the region
field in the partial unique indices for all servers tables, not just
the Microsoft servers table.

Update the adhoc_db duplicate_servers test to reflect the fact that
all servers tables, rather than just the Microsoft servers table,
should have the second region with the repeated IP address entry
added to them.

Cleanup some comments in the report_duplicates() helper method and
extend it to take as argument the index of the field to be counted,
defaulting to the first field, rather than being hardcoded to use
the first field.

Closes: #100 (again)