### PR TITLE
Add a new route to retrieve the postgres server version

### DIFF
--- a/pint_server/app.py
+++ b/pint_server/app.py
@@ -29,7 +29,7 @@ from xml.dom import minidom
 import xml.etree.ElementTree as ET
 
 import pint_server
-from pint_server.database import init_db
+from pint_server.database import init_db, get_psql_server_version
 from pint_server.models import (ImageState, AmazonImagesModel,
                                 OracleImagesModel, AlibabaImagesModel,
                                 MicrosoftImagesModel, GoogleImagesModel,
@@ -585,6 +585,13 @@ def get_package_version():
     return make_response(
         {'package version': pint_server.__VERSION__}, None, None)
 
+
+@app.route('/db-server-version', methods=['GET'])
+def get_db_server_version():
+    db_version = get_psql_server_version(db_session)
+    return make_response(
+        {'postgreSQL server version': db_version}, None, None)
+    
 
 @app.route('/', methods=['GET'])
 def redirect_to_public_cloud():

--- a/pint_server/database.py
+++ b/pint_server/database.py
@@ -21,6 +21,7 @@
 import enum
 import logging
 import os
+import re
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -213,3 +214,13 @@ def init_db(dbconfig=None, outputfile=None, echo=None,
         Base.metadata.create_all(bind=engine)
 
     return db_session
+
+
+def get_psql_server_version(db_session):
+    """Return the psql server version"""
+    result = db_session.execute("select version()")
+    for row in result:
+        version = re.search(r'PostgreSQL\s+\d+.\d+', str(row))
+        if version:
+            break
+    return version.group(0)

--- a/pint_server/tests/functional/test_function_app.py
+++ b/pint_server/tests/functional/test_function_app.py
@@ -195,6 +195,13 @@ def test_get_provider_category_data_version(baseurl, provider, category, extensi
         expected_status_code = 200
         validate(resp, expected_status_code, extension)
 
+@pytest.mark.parametrize("extension", [''])
+def test_get_psql_server_version(baseurl, extension):
+    url = baseurl + '/db-server-version'
+    resp = requests.get(url, verify=False)
+    expected_status_code = 200
+    validate(resp, expected_status_code, extension)
+
 #negative tests
 @pytest.mark.parametrize("extension", ['', '.json', '.xml'])
 @pytest.mark.parametrize("category", ['images', 'servers'])

--- a/pint_server/tests/unit/test_app.py
+++ b/pint_server/tests/unit/test_app.py
@@ -51,6 +51,14 @@ def test_unsupported_version(client, extension):
             rv = client.get(route)
             validate(rv, 400, extension)
 
+@pytest.mark.parametrize("extension", [''])
+def test_get_database_server_version(client, extension):
+    with mock.patch('pint_server.app.get_psql_server_version',
+                    return_value="14.2"):
+        route = '/db-server-version'
+        rv = client.get(route)
+        validate(rv, 200, extension)
+        assert json.loads(rv.data) == {"postgreSQL server version": "14.2"}
 
 @pytest.mark.parametrize("provider", ["alibaba", "amazon", "google", "microsoft", "oracle"])
 @pytest.mark.parametrize("extension", ['', '.json', '.xml'])


### PR DESCRIPTION
This PR adds a new route '/db-server-version which enables the ability to retrieve the psql server version, This is needed for pint-data-manager so it can dynamically determine the correct version of pg_dump to use. Currently pint-data-manager incorrectly is set for

`pg_dump = '/usr/lib/postgresql12/bin/pg_dump'`  

When testing upgrading the pint-server to PostgreSQL to version 14, an issue was found when running pint-data-manager due to the version mismatch between the psql server and pg_dump

Instead of just fixing this in pint-data-manager, it was suggested to make this a server function in case some other client would need access to the database server version.