### PR TITLE
Bump verson to 2.0.10 and export get_psql_server_version properly

### DIFF
--- a/pint_server/__init__.py
+++ b/pint_server/__init__.py
@@ -16,10 +16,10 @@
 # you may find current contact information at www.suse.com
 
 # NOTE(gyee): must update the version here on a new release
-__VERSION__ = '2.0.9'
+__VERSION__ = '2.0.10'
 
 from pint_server.database import (
-    init_db, create_postgres_url_from_config
+    init_db, create_postgres_url_from_config, get_psql_server_version
 )
 from pint_server.models import (
     AlibabaImagesModel, AmazonImagesModel,

--- a/pint_server/app.py
+++ b/pint_server/app.py
@@ -590,7 +590,7 @@ def get_package_version():
 def get_db_server_version():
     db_version = get_psql_server_version(db_session)
     return make_response(
-        {'postgreSQL server version': db_version}, None, None)
+        {'database server version': db_version}, None, None)
     
 
 @app.route('/', methods=['GET'])


### PR DESCRIPTION
This PR bumps the version to 2.0.10 and fixes a small issue where the get_psql_server_version function was not exported correctly.