### PR TITLE
Use aws python3.9 image instead of python3.6

### DIFF
--- a/Dockerfile.aws
+++ b/Dockerfile.aws
@@ -1,13 +1,9 @@
-FROM public.ecr.aws/lambda/python:3.6
+FROM public.ecr.aws/lambda/python:3.9
 
 COPY serverless_app.py requirements.txt ./
 RUN mkdir -p ./pint_server
 
 COPY pint_server/. ./pint_server
-
-
-COPY opt/. /opt
-COPY usr/. /usr
 
 # Add AWS RDS trusted certificate chain to SSL/TLS connection to the
 # RDS instance
@@ -15,7 +11,7 @@ ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem ./
 
 RUN chmod 644 /var/task/rds-combined-ca-bundle.pem
 
-RUN python3.6 -m pip install -r requirements.txt -t .
+RUN python3.9 -m pip install -r requirements.txt -t .
 
 # Command can be overwritten by providing a different command in the template directly.
 CMD ["serverless_app.handler"]

--- a/Makefile
+++ b/Makefile
@@ -2,33 +2,15 @@ all: sle15
 
 sle15: create_staging copy_sle15_dockerfile build_image clean
 
-aws: create_staging build_psycopg2_bin copy_dependent_libs copy_requirements_txt copy_aws_dockerfile build_image 
+aws: create_staging copy_requirements_txt copy_aws_dockerfile build_image 
 
 create_staging:
 	mkdir -p .staging
 	cp *.py .staging/
 	cp -r pint_server .staging/
 
-build_psycopg2_bin:
-	mkdir -p .staging/opt/python/lib/python3.6/site-packages
-	python -m pip install psycopg2 -t ".staging/opt/python/lib/python3.6/site-packages"
-
-copy_dependent_libs:
-ifneq ("$(wildcard /usr/lib/libpq.so.5)","")
-	mkdir -p .staging/usr/lib
-	cp /usr/lib/libpq.so.5 .staging/usr/lib/libpq.so.5
-	cp /usr/lib/libssl.so.1.1 .staging/usr/lib/libssl.so.1.1
-	cp /usr/lib/libcrypto.so.1.1 .staging/usr/lib/libcrypto.so.1.1
-else
-	mkdir -p .staging/usr/lib64
-	cp /usr/lib64/libpq.so.5 .staging/usr/lib64/libpq.so.5
-	cp /usr/lib64/libssl.so.1.1 .staging/usr/lib64/libssl.so.1.1
-	cp /usr/lib64/libcrypto.so.1.1 .staging/usr/lib64/libcrypto.so.1.1
-endif
-
 copy_requirements_txt:
 	cp requirements.txt .staging
-	sed -i '/^psycopg2/d' .staging/requirements.txt
 
 copy_aws_dockerfile:
 	cp Dockerfile.aws .staging/Dockerfile


### PR DESCRIPTION
AWS python3.9 image uses Amazon Linux 2 [1], which supports
native psycopg2-binary (postgre driver) out-of-the-box.
We no longer need to copying binaries around as we may run into
the risk of GLIBC incompatibilities.