### PR TITLE
Don't include deleted images in /v1/{provider}/images response

### DIFF
--- a/pint_server/app.py
+++ b/pint_server/app.py
@@ -691,7 +691,11 @@ def trim_images_payload(images):
 
 
 def get_provider_images(provider):
-    images = PROVIDER_IMAGES_MODEL_MAP[provider].query.order_by(
+    images = PROVIDER_IMAGES_MODEL_MAP[provider].query.filter(
+            PROVIDER_IMAGES_MODEL_MAP[provider].state.in_([
+                ImageState.active,
+                ImageState.inactive,
+                ImageState.deprecated])).order_by(
         desc(PROVIDER_IMAGES_MODEL_MAP[provider].publishedon)).all()
     return trim_images_payload(
                 formatted_provider_images(provider, images))


### PR DESCRIPTION
To reduce the payload size for the /v1/{provider}/images requests
we can just provide a response that includes the active, inactive
and deprecated images.

If someone wants the deleted images they can explicitly request them
with a /v1/{provider}/images/deleted request.