### PR TITLE
Sort all image queries by publishedon date

### DIFF
--- a/pint_server/tests/unit/mock_pint_data.py
+++ b/pint_server/tests/unit/mock_pint_data.py
@@ -184,6 +184,9 @@ class MockDBImagesQuery:
     def count(self):
         return len(self.images)
 
+    def __len__(self):
+        return len(self.images)
+
     def __str__(self):
         return "".join([
             "[",


### PR DESCRIPTION
To ensure that images trimmed from oversized queries are the oldest ones, it is necessary to sort the image/state query by publishedon date. For consistency, sort the other image queries the same way.