### PR TITLE
Update pint-server to version 2.0.14

### DIFF
--- a/pint_server/__init__.py
+++ b/pint_server/__init__.py
@@ -16,7 +16,7 @@
 # you may find current contact information at www.suse.com
 
 # NOTE(gyee): must update the version here on a new release
-__VERSION__ = '2.0.13'
+__VERSION__ = '2.0.14'
 
 from pint_server.database import (
     init_db, create_postgres_url_from_config, get_psql_server_version


### PR DESCRIPTION
Update the version of the pint-server to 2.0.14 to enable releasing the sorting fix for the deleted image data.