### PR TITLE
Update GitHub Actions CI workflow to use ubuntu-latest

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -5,24 +5,68 @@ on:
   - pull_request 
 
 jobs:
-  build:
 
+  # test for versions that require an older distro
+  test-legacy-versions:
+
+    # will be skipped in GitHub infrastructure, but can be run locally
+    # using nektos/act if an appropriate image is available and the
+    # RUNNING_LOCALLY variable is defined via a --var option or in a
+    # var file via the --var-file option.
+    if: vars.RUNNING_LOCALLY || false
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6.15, 3.7, 3.8]
+        python-version:
+          - 3.6.15
+          - 3.7
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          [ "${USER}" = "root" ] || PATH=${HOME}/.local/bin:${PATH}
+          python -m pip install --upgrade pip wheel setuptools
           pip install -r requirements.txt
       - name: Test with pytest
         run: |
+          [ "${USER}" = "root" ] || PATH=${HOME}/.local/bin:${PATH}
+          pip install -r test-requirements.txt
+          pytest pint_server/tests/unit/test_app.py
+
+
+  # test for versions supported by modern distro
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version:
+          - 3.8
+          - 3.9
+          - "3.10"
+          - 3.11
+          # existing requirements don't work for Python 3.12+
+          #- 3.12
+          #- 3.13
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          [ "${USER}" = "root" ] || PATH=${HOME}/.local/bin:${PATH}
+          python -m pip install --upgrade pip wheel setuptools
+          pip install -r requirements.txt
+      - name: Test with pytest
+        run: |
+          [ "${USER}" = "root" ] || PATH=${HOME}/.local/bin:${PATH}
           pip install -r test-requirements.txt
           pytest pint_server/tests/unit/test_app.py

--- a/bin/create_dev_venv.sh
+++ b/bin/create_dev_venv.sh
@@ -28,5 +28,6 @@ if [[ "$VIRTUAL_ENV" == "" ]] ; then
         virtualenv $SRCDIR/$VENV_NAME --python=python3
     fi
     . $SRCDIR/$VENV_NAME/bin/activate
+    pip install -q --upgrade pip wheel setuptools
     pip install -q -r $SRCDIR/requirements.txt
 fi

--- a/bin/create_test_venv.sh
+++ b/bin/create_test_venv.sh
@@ -28,5 +28,6 @@ if [[ "$VIRTUAL_ENV" == "" ]] ; then
         virtualenv $SRCDIR/$VENV_NAME --python=python3
     fi
     . $SRCDIR/$VENV_NAME/bin/activate
+    pip install -q --upgrade pip wheel setuptools
     pip install -q -r $SRCDIR/test-requirements.txt
 fi


### PR DESCRIPTION
Update the standard CI workflow job definition to target the latest ubuntu runner type.

Rename CI workflow jobs to reflect that they are running tests rather than building.

Create a duplicate job definition for legacy python versions that targets ubuntu-20.04, that is disabled under GitHub Actions runs, but still available to be tested locallly using nektos/act or the gh act extension.

Note that for versions of Python greater that 3.11 testing fails due to incompatible requirements.txt and test-requirements.txt package versions; these versions have been disabled until that issue has been addressed.

Ensure that the PATH is setup appropriately when using runners that run as a non-root user.

Update checkout and setup-python action versions to latest.

Ensure that the dev and test venv creation helper scripts install latest applicable versions of the pip, wheel and setuptools packages.