### PR TITLE
Python 3.11 upgrade enhancements

### DIFF
--- a/SUSE.rst
+++ b/SUSE.rst
@@ -61,13 +61,16 @@ Testing Pint Server Lamba Function Container Locally
 How To Make A Release
 =====================
 
-1. update pint_server/__init__.py '__VERSION__' attribute with the new version
-
-2. create a git annotated tag for the release version. For example:
+1. update pint_server/__init__.py '__VERSION__' and Version attribute in python-pintserver.spec with the new version.
 
    .. code-block::
 
-     git tag -a v2.0.0 -m "Release 2.0.0"
+     bumpversion patch
+
+2. push up to GitHub the annotated release tag that was created in the previous step. For example: 
+
+   .. code-block::
+
      git push --tags
 
 3. checkout the *python-PintServer* package in
@@ -79,7 +82,8 @@ How To Make A Release
 
 4. update both the *version* and *revision* values in the *_service* file
 
-5. update *python-PintServer.spec* with the new version and release
+5. Copy the spec file *python-PintServer.spec* from the `package` directory to the checked out Build Service's python-PintServer package directory.   
 
-6. submit the changes
+6. Update the *python-PintServer.changes* file by executing *osc vc*
 
+7. Build, test and submit the package

--- a/package/python-PintServer.spec
+++ b/package/python-PintServer.spec
@@ -1,0 +1,95 @@
+#
+# spec file for package python-PintServer
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%if 0%{?suse_version} >= 1600
+%define pythons %{primary_python}
+%else
+%{?sle15_python_module_pythons}
+%endif
+%global _sitelibdir %{%{pythons}_sitelib}
+
+Name:           python-PintServer
+Version:        2.0.16
+Release:        0
+Summary:        Pint Server
+License:        Apache-2.0
+Group:          Development/Languages/Python
+URL:            https://github.com/SUSE-Enceladus/public-cloud-info-service
+Source:         pint-server-2.0.16.tar.gz
+BuildRequires:  %{pythons}-pbr
+BuildRequires:  %{pythons}-dateutil
+BuildRequires:  %{pythons}-Flask
+BuildRequires:  %{pythons}-Flask-Cors
+BuildRequires:  %{pythons}-Flask-SQLAlchemy
+BuildRequires:  %{pythons}-lxml
+BuildRequires:  %{pythons}-mock
+BuildRequires:  %{pythons}-pytest
+BuildRequires:  %{pythons}-requests
+BuildRequires:  %{pythons}-setuptools
+BuildRequires:  python-pint-models
+Requires:	%{pythons}-pbr
+Requires:	%{pythons}-boto3
+Requires:	%{pythons}-botocore
+Requires:	%{pythons}-dateutil
+Requires:	%{pythons}-click
+Requires:	%{pythons}-Flask
+Requires:	%{pythons}-Flask-Cors
+Requires:	%{pythons}-Flask-SQLAlchemy
+Requires:	%{pythons}-itsdangerous
+Requires:	%{pythons}-Jinja2
+Requires:	%{pythons}-jmespath
+Requires:	%{pythons}-MarkupSafe
+Requires:	%{pythons}-psycopg2
+Requires:	%{pythons}-python-dateutil
+Requires:	%{pythons}-s3transfer
+Requires:	%{pythons}-six
+Requires:	%{pythons}-SQLAlchemy
+Requires:	%{pythons}-urllib3
+Requires:	%{pythons}-Werkzeug
+Requires:	python-pint-models
+BuildArch:      noarch
+
+%description
+Pint Server (Python Flask) application along with
+serverless-wsgi to facilitate AWS Lambda functionality.
+
+%prep
+%setup -q -n pint-server-%{version}
+
+%build
+%python_build
+
+%install
+%python_install
+# install serverless-app to /var/task
+install -m 0755 -d %{buildroot}/var/task
+install -m 0755 serverless_app.py %{buildroot}/var/task/
+
+%check
+%pytest pint_server/tests/unit
+
+%files 
+%license LICENSE
+%doc README.rst
+%{_sitelibdir}/pint_server*
+%{_sitelibdir}/pint_server-%{version}-py*.egg-info
+%dir /var/task
+/var/task/serverless_app.py
+
+%changelog
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,18 +8,19 @@ decorator==5.1.1
 Flask==2.0.3
 Flask-Cors==4.0.1
 Flask-SQLAlchemy==2.5.1
-greenlet==2.0.2
+greenlet==2.0.2 ; python_version == '3.8'
+greenlet==3.2.1 ; python_version > '3.8'
 importlib-metadata==4.8.3
 importlib-resources==5.4.0
 itsdangerous==2.0.1
 Jinja2==3.0.3
 jmespath==0.10.0
-lxml==5.2.2
+lxml==5.4.0
 Mako==1.1.6
 MarkupSafe==2.0.1
 pbr==6.0.0
 pint_models @ git+https://github.com/SUSE-Enceladus/public-cloud-info-models
-psycopg2-binary==2.9.8
+psycopg2-binary==2.9.10
 python-dateutil==2.9.0.post0
 python-editor==1.0.4
 s3transfer==0.5.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
+[bumpversion]
+current_version = 2.0.16
+commit = True
+tag = True
+
+[bumpversion:file:pint_server/__init__.py]
+
+[bumpversion:file:package/python-PintServer.spec]
+
 [metadata]
 name = pint-server
 version = attr: pint_server.__VERSION__


### PR DESCRIPTION
Implementing bumpversion
Adding python-pintserver.spec file under package folder
Update the package versions in requirements.txt so that it works for Python 3.12 and 3.12+